### PR TITLE
BUG: Add missing fpdf2 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pillow",
     "pydantic",
     "rich",
+    "fpdf2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Thank you @Lucas-C for mentioning it in https://github.com/py-pdf/pdfly/pull/28#issuecomment-1754780894 :pray: 