### PR TITLE
MAINT: In the cat subcommand, replace the usage of the deprecated PdfMerger by PdfWriter

### DIFF
--- a/pdfly/cat.py
+++ b/pdfly/cat.py
@@ -74,7 +74,7 @@ def main(
 
             reader = PdfReader(in_fs[filename])
             for page_num in range(*page_range.indices(len(reader.pages))):
-                writer.add_page(reader.pages[page_num - 1])
+                writer.add_page(reader.pages[page_num])
         writer.write(output_fh)
     except Exception:
         print(traceback.format_exc(), file=sys.stderr)

--- a/pdfly/cat.py
+++ b/pdfly/cat.py
@@ -72,7 +72,7 @@ def main(
             if filename not in in_fs:
                 in_fs[filename] = open(filename, "rb")
 
-            reader = PdfReader(filename)
+            reader = PdfReader(in_fs[filename])
             for page_num in range(*page_range.indices(len(reader.pages))):
                 writer.add_page(reader.pages[page_num - 1])
         writer.write(output_fh)

--- a/pdfly/cat.py
+++ b/pdfly/cat.py
@@ -48,8 +48,7 @@ import traceback
 from pathlib import Path
 from typing import List, Tuple
 
-from pypdf import PageRange, PdfMerger, parse_filename_page_ranges
-from pypdf import PdfReader, PdfWriter
+from pypdf import PageRange, PdfReader, PdfWriter, parse_filename_page_ranges
 
 
 def main(

--- a/pdfly/cat.py
+++ b/pdfly/cat.py
@@ -49,6 +49,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 from pypdf import PageRange, PdfMerger, parse_filename_page_ranges
+from pypdf import PdfReader, PdfWriter
 
 
 def main(
@@ -63,7 +64,8 @@ def main(
         sys.stdout.flush()
         output_fh = os.fdopen(sys.stdout.fileno(), "wb")
 
-    merger = PdfMerger()
+    #merger = PdfMerger()
+    writer = PdfWriter()
     in_fs = {}
     try:
         for filename, page_range in filename_page_ranges:  # type: ignore
@@ -71,8 +73,12 @@ def main(
                 print(filename, page_range, file=sys.stderr)
             if filename not in in_fs:
                 in_fs[filename] = open(filename, "rb")
-            merger.append(in_fs[filename], pages=page_range)
-        merger.write(output_fh)
+            #merger.append(in_fs[filename], pages=page_range)
+            reader = PdfReader(filename)
+            for page_num in range(*page_range.indices(len(reader.pages))):
+                writer.add_page(reader.pages[page_num - 1])
+        #merger.write(output_fh)
+        writer.write(output_fh)
     except Exception:
         print(traceback.format_exc(), file=sys.stderr)
         print(f"Error while reading {filename}", file=sys.stderr)

--- a/pdfly/cat.py
+++ b/pdfly/cat.py
@@ -64,7 +64,6 @@ def main(
         sys.stdout.flush()
         output_fh = os.fdopen(sys.stdout.fileno(), "wb")
 
-    #merger = PdfMerger()
     writer = PdfWriter()
     in_fs = {}
     try:
@@ -73,11 +72,10 @@ def main(
                 print(filename, page_range, file=sys.stderr)
             if filename not in in_fs:
                 in_fs[filename] = open(filename, "rb")
-            #merger.append(in_fs[filename], pages=page_range)
+
             reader = PdfReader(filename)
             for page_num in range(*page_range.indices(len(reader.pages))):
                 writer.add_page(reader.pages[page_num - 1])
-        #merger.write(output_fh)
         writer.write(output_fh)
     except Exception:
         print(traceback.format_exc(), file=sys.stderr)


### PR DESCRIPTION
Removed deprecated PdfMerger as in #31 and replaced with PdfReader and PdfWriter. No changes made to [test_case](https://github.com/py-pdf/pdfly/blob/main/tests/test_cat.py) as functionality seems to be exactly the same.

Closes #31