### PR TITLE
Fix test_cat_subset_ensure_reduced_size()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,8 @@ def run_cli(args):
 @pytest.fixture
 def two_pages_pdf_filepath(tmp_path):
     "A PDF with 2 pages, and a different image on each page"
+    # Note: prior to v2.7.9, fpdf2 produced incorrect /Resources dicts for each page (cf. fpdf2 PR #1133),
+    # leading to an "anormal" two_pages.pdf generated there, and for test_cat_subset_ensure_reduced_size() to fail.
     pdf = FPDF()
     pdf.add_page()
     pdf.image(RESOURCES_ROOT / "baleines.jpg")

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -87,7 +87,6 @@ def test_cat_subset_warn_on_missing_pages(capsys, tmp_path):
     assert "WARN" in captured.err
 
 
-@pytest.mark.xfail()  # There is currently a bug there
 def test_cat_subset_ensure_reduced_size(tmp_path, two_pages_pdf_filepath):
     exit_code = run_cli(
         [


### PR DESCRIPTION
This unit test is failing due to a bug in `fpdf2`: https://github.com/py-pdf/fpdf2/pull/1133

This PR should be merged once a new release 2.7.9 of `fpdf2` is published.