### PR TITLE
Add warning for out-of-bounds page range in pdfly cat command

### DIFF
--- a/pdfly/cat.py
+++ b/pdfly/cat.py
@@ -37,6 +37,7 @@ Examples
         In case you don't want chapter 10 before chapter 2.
 
 """
+
 # Copyright (c) 2014, Steve Witham <switham_github@mac-guyver.com>.
 # All rights reserved. This software is available under a BSD license;
 # see https://github.com/py-pdf/pypdf/LICENSE
@@ -75,8 +76,17 @@ def main(
             reader = PdfReader(in_fs[filename])
             num_pages = len(reader.pages)
             start, end, step = page_range.indices(num_pages)
-            if start < 0 or end < 0 or start >= num_pages or end > num_pages or start > end:
-                print(f"WARNING: Page range {page_range} is out of bounds", file=sys.stderr)
+            if (
+                start < 0
+                or end < 0
+                or start >= num_pages
+                or end > num_pages
+                or start > end
+            ):
+                print(
+                    f"WARNING: Page range {page_range} is out of bounds",
+                    file=sys.stderr,
+                )
             for page_num in range(*page_range.indices(len(reader.pages))):
                 writer.add_page(reader.pages[page_num])
         writer.write(output_fh)

--- a/pdfly/cat.py
+++ b/pdfly/cat.py
@@ -73,6 +73,10 @@ def main(
                 in_fs[filename] = open(filename, "rb")
 
             reader = PdfReader(in_fs[filename])
+            num_pages = len(reader.pages)
+            start, end, step = page_range.indices(num_pages)
+            if start < 0 or end < 0 or start >= num_pages or end > num_pages or start > end:
+                print(f"WARNING: Page range {page_range} is out of bounds", file=sys.stderr)
             for page_num in range(*page_range.indices(len(reader.pages))):
                 writer.add_page(reader.pages[page_num])
         writer.write(output_fh)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -71,7 +71,6 @@ def test_cat_subset_invalid_args(capsys, tmp_path, page_range):
     assert "Invalid file path or page range provided" in captured.err
 
 
-@pytest.mark.skip(reason="This check is not implemented yet")
 def test_cat_subset_warn_on_missing_pages(capsys, tmp_path):
     with chdir(tmp_path):
         exit_code = run_cli(
@@ -85,7 +84,7 @@ def test_cat_subset_warn_on_missing_pages(capsys, tmp_path):
         )
     captured = capsys.readouterr()
     assert exit_code == 0, captured
-    assert "WARN" in captured.out
+    assert "WARN" in captured.err
 
 
 @pytest.mark.xfail()  # There is currently a bug there


### PR DESCRIPTION
## PR Description

This PR addresses issue #33 where users attempting to use the `pdfly cat` command to extract a range of pages outside the number of pages in the PDF document do not receive a warning. The following changes have been made:

- **Implemented a warning message**: Added logic to check if the specified page range is out of bounds and print a warning to `stderr` if it is.
- **Removed the `pytest.skip` decorator from the test case**: Enabled the `test_cat_subset_warn_on_missing_pages` test to verify the warning message in `stderr`. 

## Testing

- Ran the updated test suite to ensure that the warning message is correctly produced and captured.
- Verified that the `test_cat_subset_warn_on_missing_pages` test passes, confirming that the warning is printed to stderr when the page range is out of bounds.