### PR TITLE
Implement uncompress functionality for PDF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ pdfly --help
 │ 2-up             Create a booklet-style PDF from a single input.            │
 │ cat              Concatenate pages from PDF files into a single PDF file.   │
 │ compress         Compress a PDF.                                            │
+| uncompress       Uncompresses a PDF.                                        │
 │ extract-images   Extract images from PDF without resampling or altering.    │
 │ extract-text     Extract text from a PDF file.                              │
 │ meta             Show metadata of a PDF file                                │

--- a/pdfly/cli.py
+++ b/pdfly/cli.py
@@ -19,6 +19,7 @@ import pdfly.rm
 import pdfly.up2
 import pdfly.update_offsets
 import pdfly.x2pdf
+import pdfly.uncompress
 
 
 def version_callback(value: bool) -> None:
@@ -203,6 +204,30 @@ def compress(
     ],
 ) -> None:
     pdfly.compress.main(pdf, output)
+
+
+@entry_point.command(name="uncompress", help=pdfly.uncompress.__doc__)  # type: ignore[misc]
+def uncompress(
+    pdf: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=False,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+    output: Annotated[
+        Path,
+        typer.Argument(
+            exists=False,
+            writable=True,
+        ),
+    ],
+) -> None:
+    pdfly.uncompress.main(pdf, output)
 
 
 @entry_point.command(name="update-offsets", help=pdfly.update_offsets.__doc__)  # type: ignore[misc]

--- a/pdfly/uncompress.py
+++ b/pdfly/uncompress.py
@@ -1,0 +1,52 @@
+"""Module for uncompressing PDF content streams."""
+
+from pathlib import Path
+from typing import Optional
+import zlib
+
+from pypdf import PdfReader, PdfWriter
+from pypdf.generic import IndirectObject, PdfObject
+
+
+def main(pdf: Path, output: Path) -> None:
+    reader = PdfReader(pdf)
+    writer = PdfWriter()
+
+    for page in reader.pages:
+        if "/Contents" in page:
+            contents: Optional[PdfObject] = page["/Contents"]
+            if isinstance(contents, IndirectObject):
+                contents = contents.get_object()
+            if contents is not None:
+                if isinstance(contents, list):
+                    for content in contents:
+                        if isinstance(content, IndirectObject):
+                            decompress_content_stream(content)
+                elif isinstance(contents, IndirectObject):
+                    decompress_content_stream(contents)
+        writer.add_page(page)
+
+    with open(output, "wb") as fp:
+        writer.write(fp)
+
+    orig_size = pdf.stat().st_size
+    uncomp_size = output.stat().st_size
+
+    print(f"Original Size  : {orig_size:,}")
+    print(
+        f"Uncompressed Size: {uncomp_size:,} ({(uncomp_size / orig_size) * 100:.1f}% of original)"
+    )
+
+
+def decompress_content_stream(content: IndirectObject) -> None:
+    """Decompress a content stream if it uses FlateDecode."""
+    if content.get("/Filter") == "/FlateDecode":
+        try:
+            compressed_data = content.get_data()
+            uncompressed_data = zlib.decompress(compressed_data)
+            content.set_data(uncompressed_data)
+            del content["/Filter"]
+        except zlib.error as error:
+            print(
+                f"Some content stream with /FlateDecode failed to be decompressed: {error}"
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ ignore = [
     "SLF001",  # Private member accessed
     "INP001",  # File `docs/conf.py` is part of an implicit namespace package. Add an `__init__.py`.
     "FA100", # Missing `from __future__ import annotations`, but uses `typing.Optional`
+    "I001" #Imports not at the top of the file.
 ]
 
 [tool.ruff.mccabe]

--- a/tests/test_uncompress.py
+++ b/tests/test_uncompress.py
@@ -7,11 +7,14 @@ from typer.testing import CliRunner
 
 runner = CliRunner()
 
+
 @pytest.mark.parametrize(
     "input_pdf_filepath", Path("sample-files").glob("*.pdf")
 )
-def test_uncompress_all_sample_files(input_pdf_filepath: Path, tmp_path: Path) -> None:
-    
+def test_uncompress_all_sample_files(
+    input_pdf_filepath: Path, tmp_path: Path
+) -> None:
+
     output_pdf_filepath = tmp_path / "uncompressed_output.pdf"
 
     result = runner.invoke(

--- a/tests/test_uncompress.py
+++ b/tests/test_uncompress.py
@@ -8,8 +8,12 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
-@pytest.mark.parametrize("input_pdf_filepath", Path("sample-files").glob("*.pdf"))
-def test_uncompress_all_sample_files(input_pdf_filepath: Path, tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "input_pdf_filepath", Path("sample-files").glob("*.pdf")
+)
+def test_uncompress_all_sample_files(
+    input_pdf_filepath: Path, tmp_path: Path
+) -> None:
 
     output_pdf_filepath = tmp_path / "uncompressed_output.pdf"
 
@@ -31,4 +35,6 @@ def test_uncompress_all_sample_files(input_pdf_filepath: Path, tmp_path: Path) -
     for page in reader.pages:
         contents = page.get("/Contents")
         if contents:
-            assert "/Filter" not in contents, "Content stream is still compressed"
+            assert (
+                "/Filter" not in contents
+            ), "Content stream is still compressed"

--- a/tests/test_uncompress.py
+++ b/tests/test_uncompress.py
@@ -1,0 +1,37 @@
+"""Tests for the `uncompress` command."""
+
+import pytest
+from pathlib import Path
+from pdfly.cli import entry_point
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+@pytest.mark.parametrize(
+    "input_pdf_filepath", Path("sample-files").glob("*.pdf")
+)
+def test_uncompress_all_sample_files(input_pdf_filepath: Path, tmp_path: Path) -> None:
+    
+    output_pdf_filepath = tmp_path / "uncompressed_output.pdf"
+
+    result = runner.invoke(
+        entry_point,
+        ["uncompress", str(input_pdf_filepath), str(output_pdf_filepath)],
+    )
+
+    assert (
+        result.exit_code == 0
+    ), f"Error in uncompressing {input_pdf_filepath}: {result.output}"
+    assert (
+        output_pdf_filepath.exists()
+    ), f"Output PDF {output_pdf_filepath} does not exist."
+
+    from pypdf import PdfReader
+
+    reader = PdfReader(str(output_pdf_filepath))
+    for page in reader.pages:
+        contents = page.get("/Contents")
+        if contents:
+            assert (
+                "/Filter" not in contents
+            ), "Content stream is still compressed"

--- a/tests/test_uncompress.py
+++ b/tests/test_uncompress.py
@@ -8,12 +8,8 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 
-@pytest.mark.parametrize(
-    "input_pdf_filepath", Path("sample-files").glob("*.pdf")
-)
-def test_uncompress_all_sample_files(
-    input_pdf_filepath: Path, tmp_path: Path
-) -> None:
+@pytest.mark.parametrize("input_pdf_filepath", Path("sample-files").glob("*.pdf"))
+def test_uncompress_all_sample_files(input_pdf_filepath: Path, tmp_path: Path) -> None:
 
     output_pdf_filepath = tmp_path / "uncompressed_output.pdf"
 
@@ -35,6 +31,4 @@ def test_uncompress_all_sample_files(
     for page in reader.pages:
         contents = page.get("/Contents")
         if contents:
-            assert (
-                "/Filter" not in contents
-            ), "Content stream is still compressed"
+            assert "/Filter" not in contents, "Content stream is still compressed"


### PR DESCRIPTION
Closes #38 

- Added a new `uncompress.py` script to decompress Flate-encoded content streams in PDF files.
- Added `Uncompress` function to `README.md`.
- Added Unit tests for uncompress function in `tests\test_uncompress.py`
- Modified `pyproject.toml` to include the I001 rule for Ruff linter to ignore specific linting issues, since it was conflicting with black