### PR TITLE
MAINT: Setting minimal fpdf2 version in pyproject.toml - fix #83

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pillow",
     "pydantic",
     "rich",
-    "fpdf2",
+    "fpdf2>=2.8.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Based on https://github.com/py-pdf/pdfly/pull/45 and a test I just made (commit: https://github.com/py-pdf/pdfly/pull/85/commits/4fa18bae6db72953e59b271b13391bc6ad408b8d - execution: https://github.com/py-pdf/pdfly/actions/runs/12223482412?pr=85), version 2.8.1 of `fpdf2` is the minimal version currently compatible.