### PR TITLE
MAINT: Setting minimal typer version in pyproject.toml - fix #84

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 
 dependencies = [
     "pypdf>=3.8.2",
-    "typer>=0.9.0",
+    "typer>=0.12.4",
     "pillow",
     "pydantic",
     "rich",


### PR DESCRIPTION
Based on the fact that:
* with `typer==0.12.3` it fails https://github.com/py-pdf/pdfly/issues/84
* with `typer==0.12.4` it works fine, _cf._ commit: https://github.com/py-pdf/pdfly/pull/86/commits/970e2e7c3ac99aaef758fd777068a9f9ac03e792 & execution: https://github.com/py-pdf/pdfly/actions/runs/12223531054?pr=86

This PR sets the minimal `typer` version to be `0.12.4`