### PR TITLE
DOC: Fix typos

### DIFF
--- a/docs/user/installation.md
+++ b/docs/user/installation.md
@@ -29,7 +29,7 @@ pipx installs the pdfly application in an isolated environment. That guarantees
 that no other applications interferes with its defpendencies.
 
 ## Python Version Support
-If ✓ is givien, it works. It is tested via CI.
+If ✓ is given, it works. It is tested via CI.
 If ✖ is given, it is guaranteed not to work.
 If it's not filled, we don't guarantee support, but it might still work.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ def run_cli(args):
 def two_pages_pdf_filepath(tmp_path):
     "A PDF with 2 pages, and a different image on each page"
     # Note: prior to v2.7.9, fpdf2 produced incorrect /Resources dicts for each page (cf. fpdf2 PR #1133),
-    # leading to an "anormal" two_pages.pdf generated there, and for test_cat_subset_ensure_reduced_size() to fail.
+    # leading to an "abnormal" two_pages.pdf generated there, and for test_cat_subset_ensure_reduced_size() to fail.
     pdf = FPDF()
     pdf.add_page()
     pdf.image(RESOURCES_ROOT / "baleines.jpg")


### PR DESCRIPTION
Found via `typos --hidden --format brief`