### PR TITLE
DOC: Minor documentation improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,28 +35,28 @@ $ pdfly --help
 
  pdfly is a pure-python cli application for manipulating PDF files.
 
-╭─ Options ─────────────────────────────────────────────────────────────────────────────╮
-│ --version                                                                             │
-│ --help             Show this message and exit.                                        │
-╰───────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ────────────────────────────────────────────────────────────────────────────╮
-│ 2-up                      Create a booklet-style PDF from a single input.             │
-│ booklet                   Reorder and two-up PDF pages for booklet printing.          │
-│ cat                       Concatenate pages from PDF files into a single PDF file.    │
-│ check-sign                Verifies the signature of a signed PDF.                     │
-│ compress                  Compress a PDF.                                             │
-│ extract-annotated-pages   Extract only the annotated pages from a PDF.                │
-│ extract-images            Extract images from PDF without resampling or altering.     │
-│ extract-text              Extract text from a PDF file.                               │
-│ meta                      Show metadata of a PDF file                                 │
-│ pagemeta                  Give details about a single page.                           │
-│ rm                        Remove pages from PDF files.                                │
-│ rotate                    Rotate specified pages by the specified amount              │
-│ sign                      Creates a signed PDF from an existing PDF file.             │
-│ uncompress                Module for uncompressing PDF content streams.               │
-│ update-offsets            Updates offsets and lengths in a simple PDF file.           │
-│ x2pdf                     Convert one or more files to PDF. Each file is a page.      │
-╰───────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ──────────────────────────────────────────────────────────────────────────────────────╮
+│ --version                                                                                      │
+│ --help             Show this message and exit.                                                 │
+╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────╮
+│ 2-up                      Create a booklet-style PDF from a single input.                      │
+│ booklet                   Reorder and two-up PDF pages for booklet printing.                   │
+│ cat                       Extract and concatenate pages from PDF files into a single PDF file. │
+│ check-sign                Verifies the signature of a signed PDF.                              │
+│ compress                  Compress a PDF.                                                      │
+│ extract-annotated-pages   Extract only the annotated pages from a PDF.                         │
+│ extract-images            Extract images from PDF without resampling or altering.              │
+│ extract-text              Extract text from a PDF file.                                        │
+│ meta                      Show metadata of a PDF file                                          │
+│ pagemeta                  Give details about a single page.                                    │
+│ rm                        Remove pages from PDF files.                                         │
+│ rotate                    Rotate specified pages by the specified amount                       │
+│ sign                      Creates a signed PDF from an existing PDF file.                      │
+│ uncompress                Module for uncompressing PDF content streams.                        │
+│ update-offsets            Updates offsets and lengths in a simple PDF file.                    │
+│ x2pdf                     Convert one or more files to PDF. Each file is a page.               │
+╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 You can see the help of every subcommand by typing `--help`:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,28 +53,28 @@ Usage
 
     pdfly is a pure-python cli application for manipulating PDF files.
 
-   ╭─ Options ─────────────────────────────────────────────────────────────────────────────╮
-   │ --version                                                                             │
-   │ --help             Show this message and exit.                                        │
-   ╰───────────────────────────────────────────────────────────────────────────────────────╯
-   ╭─ Commands ────────────────────────────────────────────────────────────────────────────╮
-   │ 2-up                      Create a booklet-style PDF from a single input.             │
-   │ booklet                   Reorder and two-up PDF pages for booklet printing.          │
-   │ cat                       Concatenate pages from PDF files into a single PDF file.    │
-   │ check-sign                Verifies the signature of a signed PDF.                     │
-   │ compress                  Compress a PDF.                                             │
-   │ extract-annotated-pages   Extract only the annotated pages from a PDF.                │
-   │ extract-images            Extract images from PDF without resampling or altering.     │
-   │ extract-text              Extract text from a PDF file.                               │
-   │ meta                      Show metadata of a PDF file                                 │
-   │ pagemeta                  Give details about a single page.                           │
-   │ rm                        Remove pages from PDF files.                                │
-   │ rotate                    Rotate specified pages by the specified amount              │
-   │ sign                      Creates a signed PDF from an existing PDF file.             │
-   │ uncompress                Module for uncompressing PDF content streams.               │
-   │ update-offsets            Updates offsets and lengths in a simple PDF file.           │
-   │ x2pdf                     Convert one or more files to PDF. Each file is a page.      │
-   ╰───────────────────────────────────────────────────────────────────────────────────────╯
+   ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────╮
+   │ --version                                                                                      │
+   │ --help             Show this message and exit.                                                 │
+   ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
+   ╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────╮
+   │ 2-up                      Create a booklet-style PDF from a single input.                      │
+   │ booklet                   Reorder and two-up PDF pages for booklet printing.                   │
+   │ cat                       Extract and concatenate pages from PDF files into a single PDF file. │
+   │ check-sign                Verifies the signature of a signed PDF.                              │
+   │ compress                  Compress a PDF.                                                      │
+   │ extract-annotated-pages   Extract only the annotated pages from a PDF.                         │
+   │ extract-images            Extract images from PDF without resampling or altering.              │
+   │ extract-text              Extract text from a PDF file.                                        │
+   │ meta                      Show metadata of a PDF file                                          │
+   │ pagemeta                  Give details about a single page.                                    │
+   │ rm                        Remove pages from PDF files.                                         │
+   │ rotate                    Rotate specified pages by the specified amount                       │
+   │ sign                      Creates a signed PDF from an existing PDF file.                      │
+   │ uncompress                Module for uncompressing PDF content streams.                        │
+   │ update-offsets            Updates offsets and lengths in a simple PDF file.                    │
+   │ x2pdf                     Convert one or more files to PDF. Each file is a page.               │
+   ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 You can see the help of every subcommand by typing ``--help``:
 

--- a/docs/user/subcommand-cat.md
+++ b/docs/user/subcommand-cat.md
@@ -11,7 +11,7 @@ pdfly cat --help
 
  Usage: pdfly cat [OPTIONS] FILENAME FN_PGRGS...
 
- Concatenate pages from PDF files into a single PDF file.
+ Extract and concatenate pages from PDF files into a single PDF file.
  Page ranges refer to the previously-named file. A file not followed by a page
  range means all the pages of the file.
  PAGE RANGES are like Python slices.


### PR DESCRIPTION
Fix minor documentation issue reported in https://github.com/py-pdf/pdfly/issues/23, regarding the `cat` subcommand.

By submitting this pull request, I confirm that my contribution is made under the terms of the [BSD 3-Clause license](https://github.com/py-pdf/pdfly/blob/master/LICENSE).
